### PR TITLE
Move beach yoga image above testimonial, below Sign up WhatsApp CTA (issue #30)

### DIFF
--- a/index.html
+++ b/index.html
@@ -245,6 +245,9 @@
   ══════════════════════════════ */
   .classes { padding: 4rem 1.5rem; background: var(--warm); }
 
+  .classes-visual-section { background: var(--warm); padding: 0 1.5rem 4rem; }
+  .classes-visual-section .classes-visual { margin-bottom: 0; }
+
   .classes-visual { position: relative; margin-bottom: 3.5rem; }
 
   .classes-img-main {
@@ -429,6 +432,8 @@
 
     .classes { padding: 5rem 3rem; }
 
+    .classes-visual-section { padding: 0 3rem 5rem; }
+
     .testimonials { padding: 2.5rem 1.5rem; }
     .testimonials-grid { display: grid; grid-template-columns: 1fr; justify-items: center; max-width: 560px; margin-left: auto; margin-right: auto; }
 
@@ -473,11 +478,11 @@
     .services-grid { grid-template-columns: repeat(3, 1fr); }
     .service-card { height: 580px; }
 
-    /* Classes two-col */
+    /* Classes: single column (visual moved below CTA) */
     .classes {
-      display: grid; grid-template-columns: 1fr 1fr;
-      gap: 5rem; padding: 7rem 6rem;
+      padding: 7rem 6rem;
     }
+    .classes-visual-section { padding: 0 6rem 7rem; }
     .classes-visual { margin-bottom: 0; }
     .classes-img-main { height: 480px; max-height: none; }
     .classes-badge { width: 128px; height: 128px; bottom: -2rem; right: -1.5rem; }
@@ -564,13 +569,6 @@
 
 <!-- CLASSES -->
 <section class="classes" id="classes">
-  <div class="classes-visual reveal">
-    <img class="classes-img-main" src="https://images.unsplash.com/photo-1545205597-3d9d02c29597?w=800&q=85&fit=crop" alt="Wellness classes" />
-    <div class="classes-badge">
-      <span class="classes-badge-num">1:1</span>
-      <span class="classes-badge-text">& group<br>sessions</span>
-    </div>
-  </div>
   <div class="classes-content reveal">
     <h2 class="section-title" style="color:var(--deep)">Choose your<br><em style="color:var(--terracotta);font-style:italic">path to wellness</em></h2>
     <p class="classes-desc">
@@ -592,6 +590,17 @@
       <svg width="15" height="15" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path d="M21 11.5a8.38 8.38 0 0 1-.9 3.8 8.5 8.5 0 0 1-7.6 4.7 8.38 8.38 0 0 1-3.8-.9L3 21l1.9-5.7a8.38 8.38 0 0 1-.9-3.8 8.5 8.5 0 0 1 4.7-7.6 8.38 8.38 0 0 1 3.8-.9h.5a8.48 8.48 0 0 1 8 8v.5z"/></svg>
       Sign Up via WhatsApp
     </a>
+  </div>
+</section>
+
+<!-- BEACH YOGA IMAGE (above testimonial, below Sign up CTA) -->
+<section class="classes-visual-section" aria-label="Group wellness">
+  <div class="classes-visual reveal">
+    <img class="classes-img-main" src="https://images.unsplash.com/photo-1545205597-3d9d02c29597?w=800&q=85&fit=crop" alt="Group yoga on the beach — wellness class by the water" />
+    <div class="classes-badge">
+      <span class="classes-badge-num">1:1</span>
+      <span class="classes-badge-text">& group<br>sessions</span>
+    </div>
   </div>
 </section>
 


### PR DESCRIPTION
Moves the beach yoga / group wellness image so it appears above the client testimonial section and below the 'Sign up via WhatsApp' CTA. Adds standalone section with matching padding and background.

Made with [Cursor](https://cursor.com)