### PR TITLE
Reduce padding around Wellness With Michelle header on mobile (issue #32)

### DIFF
--- a/index.html
+++ b/index.html
@@ -70,7 +70,7 @@
     flex-direction: column;
     justify-content: center;
     align-items: center;
-    padding: 2rem 1.5rem 2rem;
+    padding: 1.25rem 1rem 1.25rem;
     text-align: center;
   }
 


### PR DESCRIPTION
Reduces hero/header section padding on mobile: .hero-left padding from 2rem 1.5rem 2rem to 1.25rem 1rem 1.25rem. Tablet and desktop breakpoints unchanged.

Made with [Cursor](https://cursor.com)