### PR TITLE
Hero: increase location kerning to match CTA width (fixes #41)

### DIFF
--- a/index.html
+++ b/index.html
@@ -110,7 +110,7 @@
   .hero-location {
     font-size: 0.65rem;
     font-weight: 400;
-    letter-spacing: 0.2em;
+    letter-spacing: 0.52em;
     text-transform: uppercase;
     color: var(--gold);
     margin-bottom: 0.65rem;


### PR DESCRIPTION
Increases letter-spacing on hero location "GUADALAJARA | ZAPOPAN" so it horizontally matches the Book via WhatsApp CTA button width.

- `.hero-location` `letter-spacing`: 0.2em → 0.52em

Fixes #41

Made with [Cursor](https://cursor.com)