### PR TITLE
Double EN/ES language switcher size on mobile and desktop (fixes #49)

### DIFF
--- a/es.html
+++ b/es.html
@@ -33,7 +33,7 @@
 
   .lang-switcher {
     position: absolute; top: 0.75rem; right: 1rem; z-index: 10;
-    font-size: 1.36rem; font-weight: 400; letter-spacing: 0.24em;
+    font-size: 1.36rem; font-weight: 400; letter-spacing: 0.18em;
   }
   .lang-switcher a { color: rgba(247, 243, 238, 0.7); text-decoration: none; transition: color 0.2s; padding: 0.3rem 0.2rem; }
   .lang-switcher a:hover { color: var(--gold); }

--- a/index.html
+++ b/index.html
@@ -162,7 +162,7 @@
 
   .lang-switcher {
     position: absolute; top: 0.75rem; right: 1rem; z-index: 10;
-    font-size: 1.36rem; font-weight: 400; letter-spacing: 0.24em;
+    font-size: 1.36rem; font-weight: 400; letter-spacing: 0.18em;
   }
   .lang-switcher a { color: rgba(247, 243, 238, 0.7); text-decoration: none; transition: color 0.2s; padding: 0.3rem 0.2rem; }
   .lang-switcher a:hover { color: var(--gold); }


### PR DESCRIPTION
## Summary
Doubles the size of the English/Spanish (EN | ES) language switcher on both mobile and desktop.

## Changes
- **Font size:** 0.68rem → 1.36rem
- **Letter spacing:** 0.18em (adjusted from initial 0.24em)
- **Span margin:** 0.35rem → 0.7rem
- **Padding:** Added to links for better tap targets

Updated in both index.html and es.html.

Fixes #49

Made with [Cursor](https://cursor.com)