### PR TITLE
Fix Spanish hero subtitle: Transforma el cuerpo y el alma (fixes #45)

### DIFF
--- a/es.html
+++ b/es.html
@@ -170,7 +170,7 @@
   </div>
   <div class="hero-left">
     <h1 class="hero-title">Wellness With Michelle</h1>
-    <p class="hero-sub">Tu camino de bienestar es único. Transforma cuerpo y alma con pilates, meditación, reiki o una combinación hecha a tu medida.</p>
+    <p class="hero-sub">Tu camino de bienestar es único. Transforma el cuerpo y el alma con pilates, meditación, reiki o una combinación hecha a tu medida.</p>
     <div class="hero-location">Guadalajara &nbsp;|&nbsp; Zapopan</div>
     <div class="hero-buttons">
       <a href="#contact" class="btn-primary">


### PR DESCRIPTION
## Summary
Updates the Spanish hero subtitle in es.html to add the definite articles: "Transforma cuerpo y alma" → "Transforma el cuerpo y el alma"

## Changes
- es.html: Hero subtitle now reads "Tu camino de bienestar es único. Transforma el cuerpo y el alma con pilates, meditación, reiki o una combinación hecha a tu medida."

Also includes merge from main (brings in es.html for branches that didn't have it).

Fixes #45

Made with [Cursor](https://cursor.com)