### PR TITLE
Elige el camino al bienestar: one line, cursive orange (fixes #46)

### DIFF
--- a/es.html
+++ b/es.html
@@ -219,7 +219,7 @@
 
 <section class="classes" id="classes">
   <div class="classes-content reveal">
-    <h2 class="section-title" style="color:var(--deep)">Elige tu<br><em style="color:var(--terracotta);font-style:italic">camino al bienestar</em></h2>
+    <h2 class="section-title" style="color:var(--terracotta);font-style:italic">Elige el camino al bienestar</h2>
     <p class="classes-desc">
       Ya sea la atención personalizada de una sesión privada o la energía de un grupo pequeño, hay un lugar para ti. Cada formato está pensado para encontrarte donde estás.
     </p>


### PR DESCRIPTION
## Summary
Updates the Classes section heading in es.html per issue #46.

## Changes
- **Text:** "Elige tu camino al bienestar" → "Elige el camino al bienestar" (tu → el)
- **Layout:** Single line (removed line break)
- **Styling:** Cursive (italic) terracotta/orange for the full heading

Fixes #46

Made with [Cursor](https://cursor.com)