### PR TITLE
Add Bilingual/Bicultural contact info with Americas globe (fixes #54)

### DIFF
--- a/es.html
+++ b/es.html
@@ -300,6 +300,13 @@
         <p class="info-value">Clases personales y grupales</p>
       </div>
     </div>
+    <div class="contact-info-item">
+      <div class="info-icon">🌎</div>
+      <div>
+        <p class="info-label">Bilingual/Bicultural</p>
+        <p class="info-value">English | Español</p>
+      </div>
+    </div>
   </div>
 </section>
 </main>

--- a/index.html
+++ b/index.html
@@ -689,6 +689,13 @@
         <p class="info-value">Personal & Group Classes Available</p>
       </div>
     </div>
+    <div class="contact-info-item">
+      <div class="info-icon">🌎</div>
+      <div>
+        <p class="info-label">Bilingual/Bicultural</p>
+        <p class="info-value">English | Español</p>
+      </div>
+    </div>
   </div>
 </section>
 


### PR DESCRIPTION
## Summary
Adds a new item to the contact info section per issue #54.

## Changes
- **New contact-info-item** with:
  - **Icon:** 🌎 (Earth Globe Americas)
  - **Label:** Bilingual/Bicultural
  - **Value:** English | Español

- Added to both index.html (English) and es.html (Spanish)

Fixes #54

Made with [Cursor](https://cursor.com)