### PR TITLE
Add language availability to sessions/classes paragraph (fixes #57)

### DIFF
--- a/es.html
+++ b/es.html
@@ -220,7 +220,7 @@
   <div class="classes-content reveal">
     <h2 class="section-title" style="color:var(--terracotta);font-style:italic">Elige el camino al bienestar</h2>
     <p class="classes-desc">
-      Ya sea la atención personalizada de una sesión privada o la energía de un grupo pequeño, hay un lugar para ti. Cada formato está pensado para encontrarte donde estás.
+      Ya sea la atención personalizada de una sesión privada o la energía de un grupo pequeño, hay un lugar para ti. Cada formato está pensado para encontrarte donde estás. Todas las sesiones y clases están disponibles en español e inglés.
     </p>
     <div class="class-types">
       <div class="class-type">

--- a/index.html
+++ b/index.html
@@ -604,7 +604,7 @@
   <div class="classes-content reveal">
     <h2 class="section-title" style="color:var(--deep)">Choose your<br><em style="color:var(--terracotta);font-style:italic">path to wellness</em></h2>
     <p class="classes-desc">
-      Whether you prefer the focused attention of a private session or the motivating energy of a small group, there's a place for you here. Each format is designed to meet you exactly where you are.
+      Whether you prefer the focused attention of a private session or the motivating energy of a small group, there's a place for you here. Each format is designed to meet you exactly where you are. All sessions and classes are available in Spanish and English.
     </p>
     <div class="class-types">
       <div class="class-type">


### PR DESCRIPTION
Adds that all sessions and classes are available in Spanish and English:
- **English (index.html):** All sessions and classes are available in Spanish and English.
- **Spanish (es.html):** Todas las sesiones y clases están disponibles en español e inglés.

Fixes #57

Made with [Cursor](https://cursor.com)