### PR TITLE
Reduce white space around client testimonial (fixes #61)

### DIFF
--- a/es.html
+++ b/es.html
@@ -72,7 +72,7 @@
   .service-tag { display: inline-block; margin-top: 0.9rem; padding: 0.32rem 0.85rem; border: 1px solid rgba(201,169,110,0.5); color: var(--gold); font-size: 0.63rem; letter-spacing: 0.18em; text-transform: uppercase; }
 
   .classes { padding: 2rem 1.5rem; background: var(--warm); }
-  .classes-visual-section { background: var(--warm); padding: 0 1.5rem 4rem; }
+  .classes-visual-section { background: var(--warm); padding: 0 1.5rem 2.5rem; }
   .classes-visual-section .classes-visual { margin-bottom: 0; }
   .classes-visual { position: relative; margin-bottom: 3.5rem; }
   .classes-img-main { width: 100%; height: 58vw; min-height: 220px; max-height: 400px; object-fit: cover; display: block; }
@@ -89,8 +89,8 @@
   .class-type-name { font-family: 'Cormorant Garamond', serif; font-size: 1.05rem; font-weight: 400; color: var(--deep); margin-bottom: 0.25rem; }
   .class-type-desc { font-size: 0.73rem; font-weight: 200; color: rgba(44,38,32,0.6); line-height: 1.6; }
 
-  .testimonials { padding: 2rem 1.5rem; background: var(--cream); text-align: center; }
-  .testimonials-grid { display: flex; flex-direction: column; gap: 0.6rem; margin-top: 1.25rem; max-width: 560px; margin-left: auto; margin-right: auto; }
+  .testimonials { padding: 1.25rem 1.5rem; background: var(--cream); text-align: center; }
+  .testimonials-grid { display: flex; flex-direction: column; gap: 0.6rem; margin-top: 0.75rem; max-width: 560px; margin-left: auto; margin-right: auto; }
   .testimonial-card { padding: 0.9rem; background: var(--warm); border-top: 2px solid var(--sage); text-align: left; transition: transform 0.3s; }
   .testimonial-card:hover { transform: translateY(-4px); }
   .testimonial-text { font-family: 'Cormorant Garamond', serif; font-size: 1rem; font-style: italic; font-weight: 300; line-height: 1.7; color: var(--deep); margin-bottom: 1rem; }
@@ -125,8 +125,8 @@
     .services-grid { display: grid; grid-template-columns: 1fr 1fr; }
     .service-card { height: 400px; max-height: none; }
     .classes { padding: 3rem 3rem; }
-    .classes-visual-section { padding: 0 3rem 5rem; }
-    .testimonials { padding: 2.5rem 1.5rem; }
+    .classes-visual-section { padding: 0 3rem 3rem; }
+    .testimonials { padding: 1.5rem 1.5rem; }
     .testimonials-grid { display: grid; grid-template-columns: 1fr; justify-items: center; max-width: 560px; margin-left: auto; margin-right: auto; }
     .contact { padding: 3rem 2rem; }
     footer { flex-direction: row; justify-content: center; padding: 2rem 3rem; }
@@ -142,13 +142,13 @@
     .services-grid { grid-template-columns: repeat(3, 1fr); }
     .service-card { height: 580px; }
     .classes { padding: 4.25rem 6rem; }
-    .classes-visual-section { padding: 0 6rem 7rem; }
+    .classes-visual-section { padding: 0 6rem 4rem; }
     .classes-visual { margin-bottom: 0; }
     .classes-img-main { height: 480px; max-height: none; }
     .classes-badge { width: 128px; height: 128px; bottom: -2rem; right: -1.5rem; }
     .classes-badge-num { font-size: 2.2rem; }
     .classes-badge-text { font-size: 0.58rem; }
-    .testimonials { padding: 3.5rem 3rem; }
+    .testimonials { padding: 2rem 3rem; }
     .testimonials-grid { grid-template-columns: 1fr; justify-items: center; max-width: 560px; margin-left: auto; margin-right: auto; }
     .contact { display: grid; grid-template-columns: 1fr 1fr; gap: 4rem; padding: 4.5rem 4rem; }
     .whatsapp-btn { width: auto; }

--- a/index.html
+++ b/index.html
@@ -271,7 +271,7 @@
   ══════════════════════════════ */
   .classes { padding: 2rem 1.5rem; background: var(--warm); }
 
-  .classes-visual-section { background: var(--warm); padding: 0 1.5rem 4rem; }
+  .classes-visual-section { background: var(--warm); padding: 0 1.5rem 2.5rem; }
   .classes-visual-section .classes-visual { margin-bottom: 0; }
 
   .classes-visual { position: relative; margin-bottom: 3.5rem; }
@@ -335,11 +335,11 @@
   /* ══════════════════════════════
      TESTIMONIALS
   ══════════════════════════════ */
-  .testimonials { padding: 2rem 1.5rem; background: var(--cream); text-align: center; }
+  .testimonials { padding: 1.25rem 1.5rem; background: var(--cream); text-align: center; }
 
   .testimonials-grid {
     display: flex; flex-direction: column;
-    gap: 0.6rem; margin-top: 1.25rem;
+    gap: 0.6rem; margin-top: 0.75rem;
     max-width: 560px; margin-left: auto; margin-right: auto;
   }
 
@@ -456,9 +456,9 @@
 
     .classes { padding: 3rem 3rem; }
 
-    .classes-visual-section { padding: 0 3rem 5rem; }
+    .classes-visual-section { padding: 0 3rem 3rem; }
 
-    .testimonials { padding: 2.5rem 1.5rem; }
+    .testimonials { padding: 1.5rem 1.5rem; }
     .testimonials-grid { display: grid; grid-template-columns: 1fr; justify-items: center; max-width: 560px; margin-left: auto; margin-right: auto; }
 
     .contact { padding: 3rem 2rem; }
@@ -510,7 +510,7 @@
     .classes {
       padding: 4.25rem 6rem;
     }
-    .classes-visual-section { padding: 0 6rem 7rem; }
+    .classes-visual-section { padding: 0 6rem 4rem; }
     .classes-visual { margin-bottom: 0; }
     .classes-img-main { height: 480px; max-height: none; }
     .classes-badge { width: 128px; height: 128px; bottom: -2rem; right: -1.5rem; }
@@ -518,7 +518,7 @@
     .classes-badge-text { font-size: 0.58rem; }
 
     /* Testimonials 3-col */
-    .testimonials { padding: 3.5rem 3rem; }
+    .testimonials { padding: 2rem 3rem; }
     .testimonials-grid { grid-template-columns: 1fr; justify-items: center; max-width: 560px; margin-left: auto; margin-right: auto; }
 
     /* Contact two-col */


### PR DESCRIPTION
Reduces the white space around the client testimonial on both language versions.

**Changes:**
- Testimonials section padding: 2rem→1.25rem (base), 2.5rem→1.5rem (tablet), 3.5rem→2rem (desktop)
- Testimonials grid margin-top: 1.25rem→0.75rem
- Classes visual section bottom padding (space above testimonial): 4rem→2.5rem (base), 5rem→3rem (tablet), 7rem→4rem (desktop)

Fixes #61

Made with [Cursor](https://cursor.com)