### PR TITLE
Reduce white space between beach yoga pic and WhatsApp CTA on mobile (fixes #63)

### DIFF
--- a/es.html
+++ b/es.html
@@ -71,7 +71,7 @@
   .service-desc { font-size: 0.82rem; font-weight: 200; line-height: 1.7; color: rgba(247,243,238,0.8); }
   .service-tag { display: inline-block; margin-top: 0.9rem; padding: 0.32rem 0.85rem; border: 1px solid rgba(201,169,110,0.5); color: var(--gold); font-size: 0.63rem; letter-spacing: 0.18em; text-transform: uppercase; }
 
-  .classes { padding: 2rem 1.5rem; background: var(--warm); }
+  .classes { padding: 2rem 1.5rem 1rem; background: var(--warm); }
   .classes-visual-section { background: var(--warm); padding: 0 1.5rem 2.5rem; }
   .classes-visual-section .classes-visual { margin-bottom: 0; }
   .classes-visual { position: relative; margin-bottom: 3.5rem; }

--- a/index.html
+++ b/index.html
@@ -269,7 +269,7 @@
   /* ══════════════════════════════
      CLASSES
   ══════════════════════════════ */
-  .classes { padding: 2rem 1.5rem; background: var(--warm); }
+  .classes { padding: 2rem 1.5rem 1rem; background: var(--warm); }
 
   .classes-visual-section { background: var(--warm); padding: 0 1.5rem 2.5rem; }
   .classes-visual-section .classes-visual { margin-bottom: 0; }


### PR DESCRIPTION
Reduces the white space between the yoga on the beach image and the "Sign Up via WhatsApp" / "Inscribirse por WhatsApp" CTA button on the **mobile** version.

**Changes:** Classes section bottom padding on mobile: 2rem → 1rem (tablet/desktop unchanged)

Fixes #63

Made with [Cursor](https://cursor.com)