### PR TITLE
Remove reactive frame on class type cards — make static (fixes #69)

### DIFF
--- a/es.html
+++ b/es.html
@@ -83,8 +83,7 @@
   .classes-content .section-title { color: var(--deep); }
   .classes-desc { font-size: 0.88rem; font-weight: 200; line-height: 1.9; color: rgba(44,38,32,0.7); margin: 1.1rem 0 2rem; }
   .class-types { display: grid; grid-template-columns: 1fr 1fr; gap: 0.9rem; margin-bottom: 2.2rem; }
-  .class-type { padding: 1.1rem; border: 1px solid rgba(44,38,32,0.12); background: rgba(255,255,255,0.5); transition: all 0.3s; }
-  .class-type:hover { border-color: var(--terracotta); background: white; transform: translateY(-2px); }
+  .class-type { padding: 1.1rem; border: 1px solid rgba(44,38,32,0.12); background: rgba(255,255,255,0.5); }
   .class-type-icon { font-size: 1.2rem; margin-bottom: 0.4rem; }
   .class-type-name { font-family: 'Cormorant Garamond', serif; font-size: 1.05rem; font-weight: 400; color: var(--deep); margin-bottom: 0.25rem; }
   .class-type-desc { font-size: 0.73rem; font-weight: 200; color: rgba(44,38,32,0.6); line-height: 1.6; }

--- a/index.html
+++ b/index.html
@@ -319,9 +319,7 @@
     padding: 1.1rem;
     border: 1px solid rgba(44,38,32,0.12);
     background: rgba(255,255,255,0.5);
-    transition: all 0.3s;
   }
-  .class-type:hover { border-color: var(--terracotta); background: white; transform: translateY(-2px); }
 
   .class-type-icon { font-size: 1.2rem; margin-bottom: 0.4rem; }
 


### PR DESCRIPTION
Removes the hover effect on the Clases personales / Personal Classes and Sesiones grupales / Group Sessions cards. Both sections are now static with no border or transform change on hover.

**Changes:**
- Removed .class-type:hover (border-color, background, transform)
- Removed transition property

Fixes #69

Made with [Cursor](https://cursor.com)